### PR TITLE
Corresponding to Japanese yen and Fixed two bugs.

### DIFF
--- a/includes/class-xem-ajax.php
+++ b/includes/class-xem-ajax.php
@@ -154,15 +154,15 @@ class Xem_Ajax {
 				}
 			}
 			//if we also do only match on amount we try it here, but then the amount must be axactly.
-//			if(!$message_amount_match && $match_amount){
-//                $xem_amount_lock_check = round($xem_amount_locked / 1000000,$decimal_amount_precision);
-//                $xem_amount_transaction_check = round($t->transaction->amount / 1000000,$decimal_amount_precision);
-//				if( $xem_amount_lock_check ===  $xem_amount_transaction_check ){
-//					$amount_match = true;
-//					$matched_transaction = $t;
-//					break;
-//				}
-//			}
+			if(!$message_amount_match && $match_amount){
+                $xem_amount_lock_check = round($xem_amount_locked / 1000000,$decimal_amount_precision);
+                $xem_amount_transaction_check = round($t->transaction->amount / 1000000,$decimal_amount_precision);
+				if( $xem_amount_lock_check ===  $xem_amount_transaction_check ){
+					$amount_match = true;
+					$matched_transaction = $t;
+					break;
+				}
+			}
 
 		}
 

--- a/includes/class-xem-ajax.php
+++ b/includes/class-xem-ajax.php
@@ -137,7 +137,8 @@ class Xem_Ajax {
 		$message_amount_match = false;
 		$amount_match = false;
 		$matched_transaction = false;
-		$decimal_amount_precision = 0;
+		//xem amount roundprecision changed 5 from 0.
+		$decimal_amount_precision = 5;
 		foreach ($transactions as $key => $t){
 			$message = self::hex2str($t->transaction->message->payload);
 			//Check for matching message
@@ -153,15 +154,15 @@ class Xem_Ajax {
 				}
 			}
 			//if we also do only match on amount we try it here, but then the amount must be axactly.
-			if(!$message_amount_match && $match_amount){
-                $xem_amount_lock_check = round($xem_amount_locked / 1000000,$decimal_amount_precision);
-                $xem_amount_transaction_check = round($t->transaction->amount / 1000000,$decimal_amount_precision);
-				if( $xem_amount_lock_check ===  $xem_amount_transaction_check ){
-					$amount_match = true;
-					$matched_transaction = $t;
-					break;
-				}
-			}
+//			if(!$message_amount_match && $match_amount){
+//                $xem_amount_lock_check = round($xem_amount_locked / 1000000,$decimal_amount_precision);
+//                $xem_amount_transaction_check = round($t->transaction->amount / 1000000,$decimal_amount_precision);
+//				if( $xem_amount_lock_check ===  $xem_amount_transaction_check ){
+//					$amount_match = true;
+//					$matched_transaction = $t;
+//					break;
+//				}
+//			}
 
 		}
 

--- a/includes/class-xem-currency.php
+++ b/includes/class-xem-currency.php
@@ -35,6 +35,9 @@ class Xem_Currency {
                 case 'USD':
                     $response = wp_remote_get('https://api.coinmarketcap.com/v1/ticker/nem/?convert=USD');
                     break;
+		case 'JPY':
+                    $response = wp_remote_get('https://api.coinmarketcap.com/v1/ticker/nem/?convert=USD');
+                    break;
                 case 'ALL':
                     $response = wp_remote_get('https://api.coinmarketcap.com/v1/ticker/nem/?convert=USD');
                     break;
@@ -87,6 +90,9 @@ class Xem_Currency {
 			case 'USD':
 				$callback['amount'] = $amount / $data[0]->price_usd;
 				break;
+			case 'JPY':
+				$callback['amount'] = $amount / $data[0]->price_jpy;
+				break;
 			case 'BTC':
 				$callback['amount'] = $amount / $data[0]->price_btc;
 				break;
@@ -97,6 +103,9 @@ class Xem_Currency {
 				}
 				if(!empty($data[0]->price_usd)){
 					$callback['amount_usd'] = $amount / $data[0]->price_usd;
+				}
+				if(!empty($data[0]->price_jpy)){
+					$callback['amount_jpy'] = $amount / $data[0]->price_jpy;
 				}
 				if(!empty($data[0]->price_btc)){
 					$callback['amount_btc'] = $amount / $data[0]->price_btc;


### PR DESCRIPTION
-日本円に対応
-支払いxemの丸め桁数を0から5に変更。
-トランザクションのmessageが間違っていた場合でも金額が一致したら支払いを受け付けるバグを無効化。

- Corresponding to Japanese yen.
- Change the number of rounding digits of payment xem from 0 to 5.
- Even if the transaction's message was incorrect, we canceled the BUG of accepting payment if the amounts match.